### PR TITLE
remove links from name column

### DIFF
--- a/agent/Vmware.pm
+++ b/agent/Vmware.pm
@@ -146,7 +146,7 @@ sub vmware_inventory_handler {
               HOST_FOLDER => [$datacenter_details->{'value'}->{'host_folder'}],
               NETWORK_FOLDER => [$datacenter_details->{'value'}->{'network_folder'}],
               VM_FOLDER => [$datacenter_details->{'value'}->{'vm_folder'}],
-              NAME => [$datacenter_details->{'value'}->{'name'}],
+              DATACENTER_NAME => [$datacenter_details->{'value'}->{'name'}],
               DATASTORE_FOLDER => [$datacenter_details->{'value'}->{'datastore_folder'}],
            };
 
@@ -167,7 +167,7 @@ sub vmware_inventory_handler {
              {
                 DATACENTER => [$current_datacenter],
                 IS_ACCESSIBLE => [manage_json_pp_bool($datastore_details->{'value'}->{'accessible'})],
-                NAME => [$datastore_details->{'value'}->{'name'}],
+                DATASTORE_NAME => [$datastore_details->{'value'}->{'name'}],
                 DATASTORE => [$_->{'datastore'}],
                 MULTIPLE_HOST_ACCESS => [manage_json_pp_bool($datastore_details->{'value'}->{'multiple_host_access'})],
                 CAPACITY => [$_->{'capacity'}],
@@ -186,7 +186,7 @@ sub vmware_inventory_handler {
              {
                 DATACENTER => [$current_datacenter],
                 NETWORK => [$_->{'network'}],
-                NAME => [$_->{'name'}],
+                NETWORK_NAME => [$_->{'name'}],
                 TYPE => [$_->{'type'}],
              };
            }
@@ -199,7 +199,7 @@ sub vmware_inventory_handler {
              {
                 DATACENTER => [$current_datacenter],
                 FOLDER => [$_->{'folder'}],
-                NAME => [$_->{'name'}],
+                FOLDER_NAME => [$_->{'name'}],
                 TYPE => [$_->{'type'}],
              };
            }
@@ -219,7 +219,7 @@ sub vmware_inventory_handler {
                     DATACENTER => [$current_datacenter],
                     DRS_ENABLED => [manage_json_pp_bool($_->{'drs_enabled'})],
                     HA_ENABLED => [manage_json_pp_bool($_->{'ha_enabled'})],
-                    NAME => [$_->{'name'}],
+                    CLUSTER_NAME => [$_->{'name'}],
                     CLUSTER => [$_->{'cluster'}],
                  };
 
@@ -251,7 +251,7 @@ sub vmware_inventory_handler {
                         CLUSTER => [$current_cluster],
                         HOST => [$current_host],
                         RESOURCE_POOL => [$_->{'resource_pool'}],
-                        NAME => [$_->{'name'}],
+                        RESOURCEPOOL_NAME => [$_->{'name'}],
                      };
 
                      # set current resource pool
@@ -287,7 +287,7 @@ sub vmware_inventory_handler {
                             VM => [$current_vm],
                             CPU_COUNT => [$_->{'cpu_count'}],
                             POWER_STATE => [$_->{'power_state'}],
-                            NAME => [$_->{'name'}],
+                            VM_NAME => [$_->{'name'}],
                             MEMORY_SIZE_MIB => [$_->{'memory_size_MiB'}],
                             GUEST_OS => [$vm_infos_details->{'value'}->{'guest_OS'}],
                          };

--- a/install.php
+++ b/install.php
@@ -34,8 +34,8 @@ function extension_install_vmware_vcenter()
                           `HARDWARE_ID` INT(11) NOT NULL,
                           `HOST_FOLDER` VARCHAR(255) DEFAULT NULL,
                           `NETWORK_FOLDER` VARCHAR(255) DEFAULT NULL,
-    		                  `VM_FOLDER` VARCHAR(255) DEFAULT NULL,
-                          `NAME` VARCHAR(255) DEFAULT NULL,
+                          `VM_FOLDER` VARCHAR(255) DEFAULT NULL,
+                          `DATACENTER_NAME` VARCHAR(255) DEFAULT NULL,
                           `DATASTORE_FOLDER` VARCHAR(255) DEFAULT NULL,
                           PRIMARY KEY  (`ID`,`HARDWARE_ID`)
                           ) ENGINE=INNODB;");
@@ -46,7 +46,7 @@ function extension_install_vmware_vcenter()
                           `HARDWARE_ID` INT(11) NOT NULL,
                           `DATACENTER` VARCHAR(255) DEFAULT NULL,
                           `IS_ACCESSIBLE` VARCHAR(255) DEFAULT NULL,
-                          `NAME` VARCHAR(255) DEFAULT NULL,
+                          `DATASTORE_NAME` VARCHAR(255) DEFAULT NULL,
                           `DATASTORE` VARCHAR(255) DEFAULT NULL,
                           `MULTIPLE_HOST_ACCESS` VARCHAR(255) DEFAULT NULL,
                           `CAPACITY` VARCHAR(255) DEFAULT NULL,
@@ -62,7 +62,7 @@ function extension_install_vmware_vcenter()
                           `HARDWARE_ID` INT(11) NOT NULL,
                           `DATACENTER` VARCHAR(255) DEFAULT NULL,
                           `NETWORK` VARCHAR(255) DEFAULT NULL,
-                          `NAME` VARCHAR(255) DEFAULT NULL,
+                          `NETWORK_NAME` VARCHAR(255) DEFAULT NULL,
                           `TYPE` VARCHAR(255) DEFAULT NULL,
                           PRIMARY KEY  (`ID`,`HARDWARE_ID`)
                           ) ENGINE=INNODB;");
@@ -73,7 +73,7 @@ function extension_install_vmware_vcenter()
                           `HARDWARE_ID` INT(11) NOT NULL,
                           `DATACENTER` VARCHAR(255) DEFAULT NULL,
                           `FOLDER` VARCHAR(255) DEFAULT NULL,
-                          `NAME` VARCHAR(255) DEFAULT NULL,
+                          `FOLDER_NAME` VARCHAR(255) DEFAULT NULL,
                           `TYPE` VARCHAR(255) DEFAULT NULL,
                           PRIMARY KEY  (`ID`,`HARDWARE_ID`)
                           ) ENGINE=INNODB;");
@@ -85,7 +85,7 @@ function extension_install_vmware_vcenter()
                           `DATACENTER` VARCHAR(255) DEFAULT NULL,
                           `DRS_ENABLED` VARCHAR(255) DEFAULT NULL,
                           `HA_ENABLED` VARCHAR(255) DEFAULT NULL,
-                          `NAME` VARCHAR(255) DEFAULT NULL,
+                          `CLUSTER_NAME` VARCHAR(255) DEFAULT NULL,
                           `CLUSTER` VARCHAR(255) DEFAULT NULL,
                           PRIMARY KEY  (`ID`,`HARDWARE_ID`)
                           ) ENGINE=INNODB;");
@@ -99,7 +99,7 @@ function extension_install_vmware_vcenter()
                           `CLUSTER` VARCHAR(255) DEFAULT NULL,
                           `HOST` VARCHAR(255) DEFAULT NULL,
                           `RESOURCE_POOL` VARCHAR(255) DEFAULT NULL,
-                          `NAME` VARCHAR(255) DEFAULT NULL,
+                          `RESOURCEPOOL_NAME` VARCHAR(255) DEFAULT NULL,
                           PRIMARY KEY  (`ID`,`HARDWARE_ID`)
                           ) ENGINE=INNODB;");
 
@@ -114,7 +114,7 @@ function extension_install_vmware_vcenter()
                           `VM` VARCHAR(255) DEFAULT NULL,
                           `CPU_COUNT` VARCHAR(255) DEFAULT NULL,
                           `POWER_STATE` VARCHAR(255) DEFAULT NULL,
-                          `NAME` VARCHAR(255) DEFAULT NULL,
+                          `VM_NAME` VARCHAR(255) DEFAULT NULL,
                           `MEMORY_SIZE_MIB` VARCHAR(255) DEFAULT NULL,
                           `GUEST_OS` VARCHAR(255) DEFAULT NULL,
                           PRIMARY KEY  (`ID`,`HARDWARE_ID`)


### PR DESCRIPTION
Removes broken links on the NAME column (renamed by OCS to Computer, which caused a link to appear as in all computers section) by renaming the table fields